### PR TITLE
Ch2: Add Docker Compose for Keycloak 22.0.0, update initialization and configuration

### DIFF
--- a/ch2/backend/Dockerfile
+++ b/ch2/backend/Dockerfile
@@ -2,6 +2,5 @@ FROM node
 COPY package.json .
 RUN npm install
 COPY app.js .
-COPY keycloak.json .
 EXPOSE 3000
 CMD [ "npm", "start" ]

--- a/ch2/backend/keycloak.json
+++ b/ch2/backend/keycloak.json
@@ -2,6 +2,6 @@
   "realm": "myrealm",
   "bearer-only": true,
   "auth-server-url": "${env.KC_URL:http://localhost:8080}",
-  "resource": "service-nodejs",
+  "resource": "myclient",
   "verify-token-audience": false
 }

--- a/ch2/docker-compose.yml
+++ b/ch2/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+networks:
+  ch2_network:
+    driver: bridge
+
+services:
+  backend:
+    build:
+      context: ./backend
+    ports:
+      - "3000:3000"
+    environment:
+      KC_URL: https://192.168.35.177:8443
+      SERVICE_URL: http://192.168.35.177:3000/secured
+      P12_PASSWORD: 12345
+      P12_FILENAME: backend_192x168x35x177.p12
+    volumes:
+      - ./backend/certs:/app/certs
+      - ./backend:/app/src
+    networks:
+      - ch2_network
+
+  frontend:
+    build:
+      context: ./frontend
+    ports:
+      - "8000:8000"
+    environment:
+      KC_URL: https://192.168.35.177:8443
+      SERVICE_URL: http://192.168.35.177:3000/secured
+      P12_PASSWORD: 12345
+      P12_FILENAME: frontend_192x168x35x177.p12
+    volumes:
+      - ./frontend:/app/src
+      - ./frontend/certs:/app/certs
+    # entrypoint: ["/bin/sh", "-c"]
+    # command: ["tail -f /dev/null"]
+    networks:
+      - ch2_network
+

--- a/ch2/frontend/app.js
+++ b/ch2/frontend/app.js
@@ -9,14 +9,25 @@ app.use(stringReplace({
    'SERVICE_URL': SERVICE_URL,
    'KC_URL': KC_URL
 }));
-app.use(express.static('.'))
 
+// Serve static files from the current directory
+app.use(express.static('.'));
+
+// Endpoint for root ('/')
 app.get('/', function(req, res) {
-    res.render('index.html');
+    res.sendFile(__dirname + '/index.html');
 });
 
+// Endpoint for client.js
 app.get('/client.js', function(req, res) {
-    res.render('client.js');
+    res.sendFile(__dirname + '/client.js');
 });
 
-app.listen(8000);
+const parts = KC_URL.split(/[:/]+/);
+
+// Start the server
+app.listen(8000, function() {
+    console.log('Server running at http://' + parts[1] + ':8000');
+    console.log('Keycloak URL (KC_URL):',  KC_URL);
+    console.log('Service URL (SERVICE_URL):', SERVICE_URL);
+});

--- a/ch2/frontend/index.html
+++ b/ch2/frontend/index.html
@@ -35,7 +35,7 @@
             req.send();
         }
 
-        var kc = new Keycloak({ realm: 'myrealm', clientId: 'myclient' });
+        var kc = new Keycloak({ url: "KC_URL", realm: 'myrealm', clientId: 'myclient' });
         window.onload = function() {
             kc.init({'messageReceiveTimeout': 100000}).then(function() {
                 if(kc.authenticated) {

--- a/ch2/frontend/package.json
+++ b/ch2/frontend/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "start": "^5.1.0",
-    "string-replace-middleware": "^1.0.2"
+    "string-replace-middleware": "^1.0.2",
+    "keycloak-js": "^21.0.0"
   }
 }


### PR DESCRIPTION
Add Docker Compose for Keycloak 22.0.0, update initialization and configuration

- Added Docker Compose YAML for Keycloak 22.0.0 environment setup
- Included URL parameter for Keycloak object initialization
- Moved Keycloak.json settings into backend/app.js
- Disabled certificate verification in Node.js for HTTP environment
