### PR TITLE
updates V26+

### DIFF
--- a/ch2/frontend/index.html
+++ b/ch2/frontend/index.html
@@ -2,8 +2,7 @@
 <html>
 <head>
     <title>Keycloak Example Application</title>
-    <script type="text/javascript" src="KC_URL/js/keycloak.js"></script>
-    <script type="text/javascript">
+    <script type="module">
         function output(content) {
             if (typeof content === 'object') {
                 content = JSON.stringify(content, null, 2)
@@ -35,7 +34,8 @@
             req.send();
         }
 
-        var kc = new Keycloak({ realm: 'myrealm', clientId: 'myclient' });
+        import Keycloak from './node_modules/keycloak-js/lib/keycloak.js';
+        var kc = new Keycloak({ url: "KC_URL", realm: 'myrealm', clientId: 'myclient' });
         window.onload = function() {
             kc.init({'messageReceiveTimeout': 100000}).then(function() {
                 if(kc.authenticated) {
@@ -50,6 +50,7 @@
 <body>
 
 <div id="anonymous" style="display: none">
+    <!-- TODO login should be async, see https://www.keycloak.org/docs/latest/upgrading/index.html#methods-for-login-are-now-async -->
     <button onclick="window.kc.login()">Login</button>
 </div>
 

--- a/ch2/frontend/package.json
+++ b/ch2/frontend/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "express": "^4.17.1",
+    "keycloak-js": "latest",
     "start": "^5.1.0",
     "string-replace-middleware": "^1.0.2"
   }

--- a/ch4/index.html
+++ b/ch4/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>OpenID Connect Playground</title>
-    <script type="text/javascript" src="KC_URL/js/keycloak.js"></script>
+    <script type="module" src="./node_modules/keycloak-js/lib/keycloak.js"></script>
     <script type="text/javascript" src="client.js"></script>
     <link rel="stylesheet" href="styles.css">
 </head>

--- a/ch4/package.json
+++ b/ch4/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "express": "^4.17.1",
+    "keycloak-js": "latest",
     "start": "^5.1.0",
     "string-replace-middleware": "^1.0.2"
   }

--- a/ch5/backend/keycloak.json
+++ b/ch5/backend/keycloak.json
@@ -2,6 +2,6 @@
   "realm": "myrealm",
   "bearer-only": true,
   "auth-server-url": "${env.KC_URL:http://localhost:8080}",
-  "resource": "oauth-backend",
+  "resource": "oauth-playground",
   "verify-token-audience": false
 }

--- a/ch5/backend/package.json
+++ b/ch5/backend/package.json
@@ -5,9 +5,9 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "keycloak-connect": "22.0.0",
+    "keycloak-connect": "latest",
     "express": "^4.17.1",
-    "express-session": "^1.17.1",
+    "express-session": "latest",
     "cors": "^2.8.5"
   }
 }

--- a/ch5/frontend/index.html
+++ b/ch5/frontend/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>OAuth 2.0 Playground</title>
-    <script type="text/javascript" src="KC_URL/js/keycloak.js"></script>
+    <script type="module" src="./node_modules/keycloak-js/lib/keycloak.js"></script>
     <script type="text/javascript">
         var serviceUrl = 'SERVICE_URL';
     </script>

--- a/ch5/frontend/package.json
+++ b/ch5/frontend/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "express": "^4.17.1",
+    "keycloak-js": "latest",
     "start": "^5.1.0",
     "string-replace-middleware": "^1.0.2"
   }


### PR DESCRIPTION
With these updates as suggested in [Jan 5, 25 comment in Issue 24](https://github.com/PacktPublishing/Keycloak---Identity-and-Access-Management-for-Modern-Applications-2nd-Edition/issues/24#issuecomment-2571567160) and [keycloak 26 upgrade docs](https://www.keycloak.org/docs/latest/upgrading/index.html#support-for-the-umd-distribution-has-been-removed) 
```console
$ docker run -p 8000:8000 $(docker build -q .)

> keycloak-example-app@0.0.1 start
> node app.cjs
```
then the button appears http://localhost:8000. Pressing the button, in the console this line gives an error
```html
    <button onclick="window.kc.login()">Login</button>
```
probably caused by change in v26 [Methods for login are now async](https://www.keycloak.org/docs/latest/upgrading/index.html#methods-for-login-are-now-async).

Suggestions for calling `login()` async are welcomed. 
